### PR TITLE
last day of daily repeat was being omitted.

### DIFF
--- a/ical2org.py
+++ b/ical2org.py
@@ -63,7 +63,7 @@ def recurring_event_days(event_start, event_end, delta_str, start_utc, end_utc):
     else :
         event_aux = event_start
 
-    while event_aux < end_utc:
+    while event_aux <= end_utc:
         result.append( (event_aux, event_aux.tzinfo.normalize(event_aux + event_duration), 1) )
         event_aux = add_delta_dst(event_aux, delta)
     return result


### PR DESCRIPTION
Here is a sample event generated by google calendar for an event that occurs over 3 days.  In the master, the script was generating only 2 days org entries; with the simple change here, you also get the last day.

```
BEGIN:VEVENT
DTSTART;TZID=Europe/London:20131216T170000
DTEND;TZID=Europe/London:20131216T180000
RRULE:FREQ=DAILY;UNTIL=20131218T170000Z
DTSTAMP:20131214T184616Z
CREATED:20131214T184507Z
DESCRIPTION:
LAST-MODIFIED:20131214T184608Z
LOCATION:
SEQUENCE:0
STATUS:CONFIRMED
SUMMARY:Three day event
TRANSP:OPAQUE
END:VEVENT
```
