### PR TITLE
! take care of unnecessary escapes and newline for DESCRIPTION

### DIFF
--- a/ical2org.py
+++ b/ical2org.py
@@ -208,15 +208,18 @@ for comp in cal.walk():
         event_iter = generate_event_iterator(comp, start, end)
         for comp_start, comp_end, rec_event in event_iter:
             if 'SUMMARY' in comp:
-                fh_w.write("* {}\n".format(comp['SUMMARY'].to_ical())),
+                fh_w.write("* {}".format(comp['SUMMARY'].to_ical())),
             else:
-                fh_w.write("* (no title)\n"),
+                fh_w.write("* (no title)"),
             if rec_event and len(RECUR_TAG):
                 fh_w.write(" {}\n".format(RECUR_TAG))
-            else:
-                fh_w.write("\n")
+            fh_w.write("\n")
             fh_w.write("  {}--{}\n".format(orgDate(comp_start), orgDate(comp_end)))
             if 'DESCRIPTION' in comp:
-                fh_w.write("{}\n".format(comp['DESCRIPTION'].to_ical()))
+                DESCRIPTION = '\n'.join(comp['DESCRIPTION'].to_ical().split('\\n'))
+                DESCRIPTION = DESCRIPTION.replace('\\,', ',')
+                fh_w.write("{}\n".format(DESCRIPTION))
+
+            fh_w.write("\n")
     except:
         pass


### PR DESCRIPTION
Previously, `\\,` instead of `,` and `\\n` instead of newline were printed for DESCRIPTION. This commit makes `,` and `\n` get printed correctly. 
