### PR TITLE
! remove unnecessary escapes from SUMMARY

### DIFF
--- a/ical2org.py
+++ b/ical2org.py
@@ -192,7 +192,7 @@ if len(sys.argv) < 2:
     fh = sys.stdin
 else:
     fh = open(sys.argv[1],'rb')
-    
+
 if len(sys.argv) > 2:
     fh_w = open(sys.argv[2],'wb')
 else:


### PR DESCRIPTION
Removes unnecessary escapes from SUMMARY - when there is `,`, it used to write `\,`.
