### PR TITLE
Mention the default 90 days window length in help

### DIFF
--- a/ical2orgpy.py
+++ b/ical2orgpy.py
@@ -339,7 +339,7 @@ def print_timezones(ctx, param, value):
     "-d",
     default=90,
     type=click.IntRange(0, clamp=True),
-    help=("Window length in days (left & right from current time). "
+    help=("Window length in days (left & right from current time. Default is 90 days). "
           "Has to be positive."))
 @click.option(
     "--timezone",


### PR DESCRIPTION
Helps spot that there's a particular default... whereas one could think that there's no default.